### PR TITLE
Correct paths and imports for step 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We train and evaluate on Ubuntu 16.04, so if you don't have linux environment, y
 
 * If you break the traning and want to continue last training, set `load_pretrain = './checkpoints/target/` in `./src/config/train_opt.py`
 * Run `normalization.py` rescale the label images, you can use two sample images from `./data/target/train/train_label/` and `./data/source/test_label_ori/` to complete normalization between two skeleton size
-* Run `transfer.py` and get results in `./result`
+* Run `transfer.py` and get results in `./results`
 #### Face enhancement network
 
 ![](/result/fig2.png)
@@ -42,7 +42,7 @@ We train and evaluate on Ubuntu 16.04, so if you don't have linux environment, y
 * Run `./face_enhancer/main.py` train face enhancer and run`./face_enhancer/enhance.py` to gain results <br>
 This is comparision in original (left), generated image before face enhancement (median) and after enhancement (right). FaceGAN can learn the residual error between the real picture and the generated picture faces.
 
-#### Performance of face enhancement 
+#### Performance of face enhancement
 ![](/result/37500_enhanced_full.png)
 ![](/result/37500_enhanced_head.png)
 
@@ -66,5 +66,3 @@ Ubuntu 16.04 <br>
 Python 3.6.5 <br>
 Pytorch 0.4.1  <br>
 OpenCV 3.4.4  <br>
-
-

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We train and evaluate on Ubuntu 16.04, so if you don't have linux environment, y
 #### Make source pictures
 * Put source video mv.mp4 in `./data/source/` and run `make_source.py`, the label images and coordinate of head will save in `./data/source/test_label_ori/` and `./data/source/pose_souce.npy` (will use in step6). If you want to capture video by camera, you can directly run `./src/utils/save_img.py`
 #### Make target pictures
-* Put target video mv.mp4 in `./data/target/` and run `make_target.py`, `pose.npy` will save in `./data/target/`, which contain the coordinate of faces (will use in step6).
+* Rename your own target video as mv.mp4 and put it in `./data/target/` and run `make_target.py`, `pose.npy` will save in `./data/target/`, which contain the coordinate of faces (will use in step6).
 ![](/result/fig3.png)
 #### Train and use pose2vid network
 * Run `train_pose2vid.py` and check loss and full training process in `./checkpoints/`
@@ -38,8 +38,9 @@ We train and evaluate on Ubuntu 16.04, so if you don't have linux environment, y
 
 ![](/result/fig2.png)
 #### Train and use face enhancement network
-* Run `./face_enhancer/prepare.py` and check the results in `./data/face/test_sync` and `./data/face/test_real`.
-* Run `./face_enhancer/main.py` train face enhancer and run`./face_enhancer/enhance.py` to gain results <br>
+* Run `cd  ./face_enhancer`.
+* Run `prepare.py` and check the results in `data` directory at the root of the repo (`data/face/test_sync` and `data/face/test_real`).
+* Run `main.py` to rain the face enhancer. Then run `enhance.py` to obtain the results <br>
 This is comparision in original (left), generated image before face enhancement (median) and after enhancement (right). FaceGAN can learn the residual error between the real picture and the generated picture faces.
 
 #### Performance of face enhancement
@@ -47,7 +48,7 @@ This is comparision in original (left), generated image before face enhancement 
 ![](/result/37500_enhanced_head.png)
 
 #### Gain results
-* Run `make_gif.py` and make result pictures to gif picture
+* `cd` back to the root dir and run `make_gif.py` to create a gif out  of the resulting images.
 
 ![Result](/result/output.gif)
 

--- a/face_enhancer/dataset.py
+++ b/face_enhancer/dataset.py
@@ -12,8 +12,10 @@ class ImageFolderDataset(Dataset):
             with open(cache, 'rb') as f:
                 self.root, self.images, self.size = pickle.load(f)
         else:
-            self.images = sorted(os.listdir(os.path.join(root, 'test_real')))
             self.root = root
+            self.images = sorted(os.listdir(os.path.join(root, 'test_real')))
+            if self.images[0] == " ":
+                self.images.pop(0)
             tmp = imread(os.path.join(self.root, 'test_real', self.images[0]))
             self.size = tmp.shape[:-1]
             if cache is not None:
@@ -84,4 +86,3 @@ class FaceCropDataset(Dataset): #TODO FaceCropDataset
 
     def __len__(self):
         return len(self.image_dataset)
-

--- a/face_enhancer/prepare.py
+++ b/face_enhancer/prepare.py
@@ -3,15 +3,15 @@ from pathlib import Path
 import cv2
 from tqdm import tqdm
 
-face_sync_dir = Path('../data/face/ ')
+face_sync_dir = Path('../data/face/')
 face_sync_dir.mkdir(exist_ok=True)
-test_sync_dir = Path('../data/face/test_sync/ ')
+test_sync_dir = Path('../data/face/test_sync/')
 test_sync_dir.mkdir(exist_ok=True)
-test_real_dir = Path('../data/face/test_real/ ')
+test_real_dir = Path('../data/face/test_real/')
 test_real_dir.mkdir(exist_ok=True)
-test_img = Path('../data/target/test_img/ ')
+test_img = Path('../data/target/test_img/')
 test_img.mkdir(exist_ok=True)
-test_label = Path('../data/target/test_label/ ')
+test_label = Path('../data/target/test_label/')
 test_label.mkdir(exist_ok=True)
 
 train_dir = '../data/target/train/train_img/'

--- a/face_enhancer/prepare.py
+++ b/face_enhancer/prepare.py
@@ -32,15 +32,17 @@ from collections import OrderedDict
 from pathlib import Path
 from tqdm import tqdm
 import sys
-pix2pixhd_dir = Path('../src/pix2pixHD/')
-sys.path.append(str(pix2pixhd_dir))
+root_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.append(root_dir)
+pix2pixhd_dir=os.path.join(root_dir, "src/pix2pixHD/")
+sys.path.append(pix2pixhd_dir)
 
 from data.data_loader import CreateDataLoader
 from models.models import create_model
 import util.util as util
 from util.visualizer import Visualizer
 from util import html
-import src.config.test_opt as opt
+from src.config import test_opt as opt
 os.environ['CUDA_VISIBLE_DEVICES'] = "0"
 opt.checkpoints_dir = '../checkpoints/'
 opt.dataroot='../data/target/'
@@ -74,5 +76,3 @@ synthesized_image_dir = './prepare/target/test_latest/images/'
 for img_idx in tqdm(range(len(os.listdir(synthesized_image_dir)))):
     img = cv2.imread(synthesized_image_dir+' {:05}_synthesized_image.jpg'.format(img_idx))
     cv2.imwrite(str(test_sync_dir) + '{:05}.png'.format(img_idx), img)
-
-

--- a/normalization.py
+++ b/normalization.py
@@ -13,8 +13,8 @@ from pathlib import Path
 
 target_img = cv2.imread('./data/target/train/train_label/00001.png')[:,:,0]
 target_img_rgb = cv2.imread('./data/target/train/train_img/00001.png')
-source_img = cv2.imread('./data/target/train/train_label/00001.png')[:,:,0]
-source_img_rgb = cv2.imread('./data/target/train/train_img/00001.png')
+source_img = cv2.imread('./data/source/test_label_ori/00001.png')[:,:,0]
+source_img_rgb = cv2.imread('./data/source/test_img/00001.png')
 
 path = './data/source/test_label_ori/'
 save_dir = Path('./data/source/')


### PR DESCRIPTION
This  was first pointed out in issue #53. I read the complete [normalization.py](https://github.com/CUHKSZ-TQL/EverybodyDanceNow_reproduce_pytorch/blob/master/normalization.py) script and seems like is not a code braking issue to have equal paths for target and source:

https://github.com/CUHKSZ-TQL/EverybodyDanceNow_reproduce_pytorch/blob/0080a4debceabfcccd777d13da9c083621c809c4/normalization.py#L14-L17

In any case source and target images/labels are all 512x512  and  `get_scale()` does not require poses data to estimate the  scale of the image and the head. However, for the sake of clarity and debugging I amended the paths. 

There was also a typo in the README, about the  output directory of [transfer.py](https://github.com/CUHKSZ-TQL/EverybodyDanceNow_reproduce_pytorch/blob/master/transfer.py).

In addition I fixed  the imports (no module named src) and paths problem in (preapare.py)[https://github.com/CUHKSZ-TQL/EverybodyDanceNow_reproduce_pytorch/blob/master/face_enhancer/prepare.py] that were reported in #29, #14, #37 and #28. I made small corrections in the README to make it more clear how to execute the face enhancement step.

Finally, I add a fix for the dataset loading error reported in #43.


Hope this helps.